### PR TITLE
SimpleXMLElement::addChild erzeugt Warnung

### DIFF
--- a/classes/provider.php
+++ b/classes/provider.php
@@ -119,7 +119,7 @@ abstract class provider {
                 $contact = $this->results[$i];
                 $entry = $xml->addChild( 'entry' );
                 foreach ( $contact->getAttributes() AS $attr => $val ) {
-                    $entry->addChild( $attr, $val );
+                    $entry->addChild( $attr, htmlspecialchars($val) );
                 }
             }
         }


### PR DESCRIPTION
Wenn man das Docker Image verwendet, wird beim Aufruf der test.html nach dem Absenden unter Umständen Warnings in den Output generiert:

`SimpleXMLElement::addChild(): unterminated entity reference`

Anscheinend beschreibt die Warning, dass im Value Symbole genutzt werden, die im XML eine besondere Bedeutung haben. Also bspw `&`. Dies kann man bei Namen wie "Schmitt GmbH & Co KG" sehen. 

