### PR TITLE
Use production php.ini for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM php:apache
 
+# Set recommended php settings for production
+# This also improves logging.
+RUN cp -v /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
+
 COPY api.php /var/www/html/api.php
 COPY test.html /var/www/html/test.html
 COPY classes /var/www/html/classes/


### PR DESCRIPTION
This improves logging and avoids errors and warnings being sent to the user. Which breaks the XML output too.